### PR TITLE
Rewrite ELF to be less messy & improve error reporting

### DIFF
--- a/loader/include/elf.h
+++ b/loader/include/elf.h
@@ -2,7 +2,24 @@
 
 #include "common/types.h"
 
-struct binary_info {
+#define ELF_ALLOCATE_ANYWHERE     (1 << 0)
+#define ELF_USE_VIRTUAL_ADDRESSES (1 << 1)
+
+struct elf_load_spec {
+    void *data;
+    size_t size;
+
+    u32 memory_type;
+    u32 flags;
+};
+
+enum elf_arch {
+    ELF_ARCH_INVALID = 0,
+    ELF_ARCH_I386    = 1,
+    ELF_ARCH_AMD64   = 2,
+};
+
+struct elf_binary_info {
     u64 entrypoint_address;
 
     u64 virtual_base;
@@ -11,15 +28,21 @@ struct binary_info {
     u64 physical_base;
     u64 physical_ceiling;
 
-    u8 bitness;
+    enum elf_arch arch;
     bool kernel_range_is_direct_map;
 };
 
-struct load_result {
-    struct binary_info info;
-    const char *error_msg;
+struct elf_error {
+    const char *reason;
+    u64 args[3];
+    u8 arg_count;
 };
 
-bool elf_load(void *file_data, size_t size, bool use_va, bool allocate_anywhere,
-              u32 binary_alloc_type, struct load_result *res);
-u8 elf_bitness(void *file_data, size_t size);
+bool elf_load(const struct elf_load_spec *spec,
+              struct elf_binary_info *out_info,
+              struct elf_error *out_error);
+
+bool elf_get_arch(void *hdr_data, size_t size,
+                  enum elf_arch *arch, struct elf_error *err);
+
+void elf_pretty_print_error(const struct elf_error *err, const char *prefix);


### PR DESCRIPTION
- Pass all parameters via a specification structure, instead of direct arguments so that it is easier to extend and fill. Same way it was done for allocation utilities with allocation_spec.
- Make error reporting more verbose by introducing the ability to provide extra numeric arguments for each error. This is accomplished via the elf_error structure used by all errorable functions.
- Replace awkward elf_bitness with elf_arch and make the getter return an elf_error.
- Add an elf_pretty_print_error helper that can be reused by callers to print the error & all of the available arguments with an optional prefix.