### PR TITLE
Add just `build/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 build-*/
 !toolchain
 toolchain/*


### PR DESCRIPTION
`cmake -Bbuild` is a pretty common pattern for non-IDE generated caches so this is kind of nice to have