### PR TITLE
De-x86ify virtual memory subsystem

### DIFF
--- a/loader/arch/x86/include/arch/virtual_memory.h
+++ b/loader/arch/x86/include/arch/virtual_memory.h
@@ -18,3 +18,8 @@ static inline size_t pt_depth(enum pt_type pt)
 {
     return (size_t)pt;
 }
+
+static inline bool pt_is_huge_page(u64 entry)
+{
+    return (entry & PAGE_HUGE) == PAGE_HUGE;
+}

--- a/loader/arch/x86/include/arch/virtual_memory.h
+++ b/loader/arch/x86/include/arch/virtual_memory.h
@@ -4,6 +4,7 @@
 
 #define PAGE_PRESENT   (1 << 0)
 #define PAGE_READWRITE (1 << 1)
+#define PAGE_NORMAL    (0 << 7)
 #define PAGE_HUGE      (1 << 7)
 
 enum pt_type {

--- a/loader/arch/x86/virtual_memory.c
+++ b/loader/arch/x86/virtual_memory.c
@@ -29,6 +29,9 @@ void page_table_init(struct page_table *pt, enum pt_type type,
     pt->base_shift = PAGE_SHIFT;
     pt->max_table_address = max_table_address;
 
+    // 52 is the maximum supported number of physical bits
+    pt->entry_address_mask = ~(BIT_MASK(52, 64) | BIT_MASK(0, PAGE_SHIFT));
+
     memzero(pt->root, PAGE_SIZE);
 
     switch (type) {

--- a/loader/arch/x86/virtual_memory.c
+++ b/loader/arch/x86/virtual_memory.c
@@ -32,20 +32,20 @@ void page_table_init(struct page_table *pt, enum pt_type type,
     memzero(pt->root, PAGE_SIZE);
 
     switch (type) {
-        case PT_TYPE_I386_NO_PAE:
-            pt->entry_width = 4;
-            pt->table_width_shift = 10;
-            break;
+    case PT_TYPE_I386_NO_PAE:
+        pt->entry_width = 4;
+        pt->table_width_shift = 10;
+        break;
 
-        case PT_TYPE_I386_PAE:
-        case PT_TYPE_AMD64_4LVL:
-        case PT_TYPE_AMD64_5LVL:
-            pt->entry_width = 8;
-            pt->table_width_shift = 9;
-            break;
+    case PT_TYPE_I386_PAE:
+    case PT_TYPE_AMD64_4LVL:
+    case PT_TYPE_AMD64_5LVL:
+        pt->entry_width = 8;
+        pt->table_width_shift = 9;
+        break;
 
-        default:
-            BUG();
+    default:
+        BUG();
     }
 
     if (pt->entry_width == 8) {

--- a/loader/include/common/align.h
+++ b/loader/include/common/align.h
@@ -13,3 +13,6 @@
 
 #define PAGE_ROUND_UP(size)   ALIGN_UP(size, PAGE_SIZE)
 #define PAGE_ROUND_DOWN(size) ALIGN_DOWN(size, PAGE_SIZE)
+
+#define BIT_MASK(start_bit, end_bit) \
+    (((1ull << ((end_bit) - (start_bit))) - 1) << start_bit)

--- a/loader/include/virtual_memory.h
+++ b/loader/include/virtual_memory.h
@@ -9,6 +9,7 @@ struct page_table {
     void (*write_slot)(void*, u64);
     u64 (*read_slot)(void*);
     u64 max_table_address;
+    u64 entry_address_mask;
     u8 table_width_shift;
     u8 levels;
     u8 entry_width;

--- a/loader/virtual_memory.c
+++ b/loader/virtual_memory.c
@@ -69,7 +69,7 @@ static void *table_at(struct page_table *pt, void *table, size_t idx)
     memzero((void*)page, PAGE_SIZE);
 
     entry = (ptr_t)page;
-    entry |= PAGE_READWRITE | PAGE_PRESENT;
+    entry |= PAGE_READWRITE | PAGE_PRESENT | PAGE_NORMAL;
 
     pt->write_slot(table, entry);
     return page;

--- a/loader/virtual_memory.c
+++ b/loader/virtual_memory.c
@@ -59,7 +59,7 @@ static void *table_at(struct page_table *pt, void *table, size_t idx)
     if (entry & PAGE_PRESENT) {
         BUG_ON(pt_is_huge_page(entry));
 
-        entry &= ~((1 << pt->base_shift) - 1);
+        entry = entry & pt->entry_address_mask;
         return (void*)((ptr_t)entry);
     }
 

--- a/loader/virtual_memory.c
+++ b/loader/virtual_memory.c
@@ -57,7 +57,7 @@ static void *table_at(struct page_table *pt, void *table, size_t idx)
     entry = pt->read_slot(table);
 
     if (entry & PAGE_PRESENT) {
-        BUG_ON(entry & PAGE_HUGE);
+        BUG_ON(pt_is_huge_page(entry));
 
         entry &= ~((1 << pt->base_shift) - 1);
         return (void*)((ptr_t)entry);


### PR DESCRIPTION
Rework certain places where we relied on the x86 page table structures too much that the assumptions leaked into generic code.