### PR TITLE
Fix Windows-hosted builds and toolchain injection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,12 @@ if ($ENV{CLION_IDE})
     message("Detected CLion, using a dummy toolchain file")
 endif ()
 
-set(HYPER_TOOLCHAIN_DIR "${CMAKE_SOURCE_DIR}/toolchain")
-include("${HYPER_TOOLCHAIN_DIR}/toolchain_${HYPER_TOOLCHAIN}.cmake")
+if (HYPER_TOOLCHAIN STREQUAL "gcc" OR HYPER_TOOLCHAIN STREQUAL "clang")
+    set(HYPER_TOOLCHAIN_DIR "${CMAKE_SOURCE_DIR}/toolchain")
+    include("${HYPER_TOOLCHAIN_DIR}/toolchain_${HYPER_TOOLCHAIN}.cmake")
+else ()
+    include("${HYPER_TOOLCHAIN}")
+endif()
 
 project(Hyper C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,16 +33,14 @@ if (HYPER_TOOLCHAIN)
 endif ()
 
 if (NOT HYPER_TOOLCHAIN)
-    set(HYPER_TOOLCHAIN "gcc")
-elseif (NOT HYPER_TOOLCHAIN STREQUAL "gcc" AND
-        NOT HYPER_TOOLCHAIN STREQUAL "clang")
-    message(FATAL_ERROR "Unknown toolchain '${HYPER_TOOLCHAIN}'")
+    if ($ENV{CLION_IDE})
+        set(HYPER_TOOLCHAIN dummy)
+        message("Detected CLion, using a dummy toolchain file")
+    else ()
+        set(HYPER_TOOLCHAIN "gcc")
+    endif ()
 endif ()
 
-if ($ENV{CLION_IDE})
-    set(HYPER_TOOLCHAIN dummy)
-    message("Detected CLion, using a dummy toolchain file")
-endif ()
 
 if (HYPER_TOOLCHAIN STREQUAL "gcc" OR HYPER_TOOLCHAIN STREQUAL "clang")
     set(HYPER_TOOLCHAIN_DIR "${CMAKE_SOURCE_DIR}/toolchain")

--- a/installer/hyper_install.c
+++ b/installer/hyper_install.c
@@ -34,8 +34,10 @@ struct mbr_partition_entry {
 #define MBR_PARTITION_COUNT 4
 
 _Noreturn
-#ifdef __GNUC__
+#ifdef __clang__
 __attribute__((format(printf, 1, 2)))
+#elif defined(__GNUC__)
+__attribute__((format(gnu_printf, 1, 2)))
 #endif
 void panic(const char *err, ...)
 {

--- a/loader/arch/x86/bios/CMakeLists.txt
+++ b/loader/arch/x86/bios/CMakeLists.txt
@@ -49,7 +49,7 @@ add_custom_command(
     OUTPUT
     ${ISO_STAGE2_FULL_PATH}
     COMMAND
-    cat ${ISO_BOOT_REC_FULL_PATH} ${STAGE2_FULL_PATH} > ${ISO_STAGE2_FULL_PATH}
+    "${CMAKE_COMMAND}" -E cat ${ISO_BOOT_REC_FULL_PATH} ${STAGE2_FULL_PATH} > ${ISO_STAGE2_FULL_PATH}
     DEPENDS
     ${ISO_BOOT_REC_BINARY} ${STAGE2_BINARY}
     COMMENT
@@ -62,10 +62,18 @@ ExternalProject_Add(
     installer
     SOURCE_DIR
     ${PROJECT_SOURCE_DIR}/installer
+    BUILD_COMMAND
+    "${CMAKE_MAKE_PROGRAM}"
     CMAKE_ARGS
     -DMBR_PATH=${MBR_FULL_PATH}
     -DISO_MBR_PATH=${ISO_MBR_FULL_PATH}
     -DSTAGE2_PATH=${STAGE2_FULL_PATH}
+    -DCMAKE_MAKE_PROGRAM="${CMAKE_MAKE_PROGRAM}"
+    # Don't inherit C compiler which may be tied to target rather than host.
+    # There should ideally be a way to pass this through or otherwise request
+    # A toolchain from the subproject.
+    #-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_C_COMPILER_WORKS=1
     INSTALL_COMMAND
     cmake -E echo "Skipping install step"
 )

--- a/loader/arch/x86/bios/bios_video_services.c
+++ b/loader/arch/x86/bios/bios_video_services.c
@@ -327,7 +327,7 @@ static void fetch_all_video_modes(void)
         if (fb_format == FB_FORMAT_INVALID)
             continue;
 
-	if (video_mode_count == MODE_BUFFER_CAPACITY) {
+        if (video_mode_count == MODE_BUFFER_CAPACITY) {
             print_warn("exceeded video mode storage capacity, skipping the rest\n");
             return;
         }

--- a/loader/arch/x86/bios/boot_record/CMakeLists.txt
+++ b/loader/arch/x86/bios/boot_record/CMakeLists.txt
@@ -5,7 +5,8 @@ project(BootRecord ASM_NASM)
 set(CMAKE_ASM_NASM_FLAGS -fbin)
 
 # Prevent cmake from attempting to link the flat binary
-set(CMAKE_ASM_NASM_LINK_EXECUTABLE "cp <OBJECTS> <TARGET>")
+set(CMAKE_ASM_NASM_LINK_EXECUTABLE
+        "\"${CMAKE_COMMAND}\" -E copy \"<OBJECTS>\" \"<TARGET>\"")
 
 add_executable(hyper_mbr boot_record.asm)
 


### PR DESCRIPTION
Fixed hosting of builds under typical Windows shells and added a more robust way to inject toolchain files from a secondary project